### PR TITLE
Replaces deprecated ioutil usage.

### DIFF
--- a/discord/discord_test.go
+++ b/discord/discord_test.go
@@ -1,7 +1,7 @@
 package discord
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,7 +15,7 @@ func TestNew(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/slack/slack_test.go
+++ b/slack/slack_test.go
@@ -1,7 +1,7 @@
 package slack
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,7 +15,7 @@ func TestNew(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
### **User description**
Replace usage of deprecated `io/ioutil` with functionally equivalent usage of the `io` package as it was deprecated as of Go 1.16.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replaced deprecated `ioutil.ReadAll` with `io.ReadAll`.

- Updated test files to use the `io` package.

- Ensured compatibility with Go 1.16 and later versions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>discord_test.go</strong><dd><code>Replace deprecated `ioutil` in Discord tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

discord/discord_test.go

<li>Replaced <code>ioutil.ReadAll</code> with <code>io.ReadAll</code>.<br> <li> Updated imports to use <code>io</code> package.


</details>


  </td>
  <td><a href="https://github.com/ttys3/consul-alert/pull/10/files#diff-a600eed2f78bf3eb3c15c08d95b2f393e1daaa8686ad639601380fea0775a1c8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>slack_test.go</strong><dd><code>Replace deprecated `ioutil` in Slack tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

slack/slack_test.go

<li>Replaced <code>ioutil.ReadAll</code> with <code>io.ReadAll</code>.<br> <li> Updated imports to use <code>io</code> package.


</details>


  </td>
  <td><a href="https://github.com/ttys3/consul-alert/pull/10/files#diff-a61d6f9cf11fd3359df2a95caca0a9a76acf5ccad046d2d5eca74004ae10b1c6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>